### PR TITLE
Better handle TZ with Exchange / M365 generated iCal files

### DIFF
--- a/src/RfcParser.php
+++ b/src/RfcParser.php
@@ -221,7 +221,7 @@ class RfcParser
 		foreach ($property['params'] as $name => $value) {
 			switch (strtoupper($name)) {
 				case 'TZID':
-					$tz = new \DateTimeZone($value);
+					$tz = self::parseTimeZone($value);
 				break;
 				case 'VALUE':
 					switch ($value) {
@@ -284,7 +284,7 @@ class RfcParser
 					// Ignore optional words
 					break;
 				case 'TZID':
-					$tz = new \DateTimeZone($value);
+					$tz = self::parseTimeZone($value);
 				break;
 				default:
 					throw new \InvalidArgumentException("Unknown property parameter: $name");


### PR DESCRIPTION
The RfcParser currently fails, if the iCal file includes Microsoft-like timezone strings (like "W. Europe Standard Time"). This is intended to use the (already available) tz parser.